### PR TITLE
Bugfix: Allow custom csv_options

### DIFF
--- a/lib/csv-machine.rb
+++ b/lib/csv-machine.rb
@@ -19,13 +19,14 @@ module CSVMachine
     end
 
     def csv_options
-      @csv_options ||= CSV::DEFAULT_OPTIONS
+      @csv_options ||= CSV::DEFAULT_OPTIONS.dup
     end
 
     # @param [Symbol] name
     # @param [] value
     def set_csv_option(name, value)
       raise "Unknown csv option `#{name}'" unless csv_options.key?(name)
+      @csv_options[name] = value
     end
 
     # @param [Symbol, #to_sym] name

--- a/test/test_csv-machine.rb
+++ b/test/test_csv-machine.rb
@@ -42,7 +42,33 @@ CSV
     assert_equal(3, @all_stars.size)
     @all_stars.each do |all_star|
       assert_instance_of(AllStar, all_star)
-    
+
+      assert_respond_to(all_star, :first_name)
+      assert_respond_to(all_star, :last_name)
+      assert_respond_to(all_star, :team)
+    end
+    player = @all_stars.first
+    assert_equal("Kevin", player.first_name)
+    assert_equal("Durant", player.last_name)
+    assert_equal("Oklahoma City Thunder", player.team)
+  end
+
+  def test_parse_with_custom_csv_option
+    data = <<-CSV
+Last name, First name, Position, Number, Team
+Durant,Kevin,Small Forward,35,Oklahoma City Thunder
+Bryant,Kobe,Shooting Guard,24,Los Angeles Lakers
+James,LeBron,Power Forward,6,Miami Heat
+CSV
+    @all_stars = []
+    assert_nothing_raised do
+      AllStar.set_csv_option(:headers, :first_row)
+      @all_stars = AllStar.parse(data)
+    end
+    assert_equal(3, @all_stars.size)
+    @all_stars.each do |all_star|
+      assert_instance_of(AllStar, all_star)
+
       assert_respond_to(all_star, :first_name)
       assert_respond_to(all_star, :last_name)
       assert_respond_to(all_star, :team)


### PR DESCRIPTION
Run options:
# Running tests:

Finished tests in 0.003911s, 1022.7563 tests/s, 9716.1851 assertions/s.
4 tests, 38 assertions, 0 failures, 0 errors, 0 skips

ruby -v: ruby 2.1.3p242 (2014-09-19 revision 47630) [x86_64-darwin13.0]

closes #3 
